### PR TITLE
Permit installation alongside modern versions of requests.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-required = ['requests == 2.6.0', 'requests_oauthlib == 0.4.2']
+required = ['requests>=2.6.0', 'requests_oauthlib>=0.4.2']
 
 setup(
     author='Factual Driver Team',


### PR DESCRIPTION
Per commit message, it's not possible to use the setuptools entry_points feature without a patched factual-api.

----

Can't use modern requests in an app that uses factual-api, without
setuptools entry_point scripts failing while resolving dependent
packages.